### PR TITLE
fixed PY2 import error on older versions of six

### DIFF
--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -12,7 +12,6 @@ except ImportError:
     import sys    
     PY2 = sys.version_info[0] == 2
     
-
 class CSVRenderer(BaseRenderer):
     """
     Renderer which serializes to CSV


### PR DESCRIPTION
Older versions of six don't have the `PY2` variable. This is causing issues with certain projects that use older versions of six.
