### PR TITLE
CSVRenderer accepts extra kwargs for csv writer.

### DIFF
--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -25,7 +25,7 @@ class CSVRenderer(BaseRenderer):
 
     def __init__(self, delimiter=',', *args, **kwargs):
         self.delimiter = delimiter
-        super(CSVRenderer, self).__init__(self, *args, **kwargs)
+        super(CSVRenderer, self).__init__(*args, **kwargs)
 
     def render(self, data, media_type=None, renderer_context=None):
         """

--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 import csv
-from collections import defaultdict
 from rest_framework.renderers import *
 from six import StringIO, text_type
 from rest_framework_csv.orderedrows import OrderedRows
@@ -10,9 +9,10 @@ from rest_framework_csv.misc import Echo
 try:
     from six import PY2
 except ImportError:
-    import sys    
+    import sys
     PY2 = sys.version_info[0] == 2
-    
+
+
 class CSVRenderer(BaseRenderer):
     """
     Renderer which serializes to CSV

--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -23,11 +23,7 @@ class CSVRenderer(BaseRenderer):
     level_sep = '.'
     headers = None
 
-    def __init__(self, delimiter=',', *args, **kwargs):
-        self.delimiter = delimiter
-        super(CSVRenderer, self).__init__(*args, **kwargs)
-
-    def render(self, data, media_type=None, renderer_context=None):
+    def render(self, data, media_type=None, renderer_context=None, writer_opts=None):
         """
         Renders serialized *data* into CSV. For a dictionary:
         """
@@ -37,9 +33,12 @@ class CSVRenderer(BaseRenderer):
         if not isinstance(data, list):
             data = [data]
 
+        if writer_opts is None:
+            writer_opts = {}
+
         table = self.tablize(data)
         csv_buffer = StringIO()
-        csv_writer = csv.writer(csv_buffer, delimiter=self.delimiter)
+        csv_writer = csv.writer(csv_buffer, **writer_opts)
         for row in table:
             # Assume that strings should be encoded as UTF-8
             csv_writer.writerow([

--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -23,6 +23,10 @@ class CSVRenderer(BaseRenderer):
     level_sep = '.'
     headers = None
 
+    def __init__(self, delimiter=',', *args, **kwargs):
+        self.delimiter = delimiter
+        super(CSVRenderer, self).__init__(self, *args, **kwargs)
+
     def render(self, data, media_type=None, renderer_context=None):
         """
         Renders serialized *data* into CSV. For a dictionary:
@@ -35,7 +39,7 @@ class CSVRenderer(BaseRenderer):
 
         table = self.tablize(data)
         csv_buffer = StringIO()
-        csv_writer = csv.writer(csv_buffer)
+        csv_writer = csv.writer(csv_buffer, delimiter=self.delimiter)
         for row in table:
             # Assume that strings should be encoded as UTF-8
             csv_writer.writerow([


### PR DESCRIPTION
Be flexible about the delimiter.

I choose to use a __init__ parameter,  because create a new class just to override an attribute seems to be much.

This PR is related to : https://github.com/mjumbewu/django-rest-framework-csv/issues/25