### PR TITLE
Toxify the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 /.settings/
 /.pydevproject
 /.project
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: python
-python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
 env:
-  - DJANGO="django<1.5"  # Django 1.4 (LTS)
-  - DJANGO="django<1.7"  # Django 1.6
-  - DJANGO="django<1.8"  # Django 1.7
-install:
-  - pip install -q $DJANGO --use-mirrors
-  - pip install -q -r requirements.txt --use-mirrors
-script: python manage.py test
+  - TOXENV=py27-django14
+  - TOXENV=py32-django16
+  - TOXENV=py32-django17
+  - TOXENV=py33-django16
+  - TOXENV=py33-django17
 
-matrix:
-  exclude:
-    - python: "3.2"
-      env: DJANGO="django<1.5"
-    - python: "3.3"
-      env: DJANGO="django<1.5"
+install:
+  - pip install tox
+
+script: tox -e $TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27-django14,
+	  {py27,py32,py33}-django{16,17}
+
+[testenv]
+commands = python manage.py test
+deps = 
+    djangorestframework
+    six>=1.4.1
+    django14: Django>=1.4,<1.5
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8


### PR DESCRIPTION
Makes easier to test locally with all supported versions of project's dependencies.