### PR TITLE
Allow for header and labels setting with CSVStreamingRenderer

### DIFF
--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -201,12 +201,13 @@ class CSVStreamingRenderer(CSVRenderer):
         if data is None:
             yield ''
 
-        self.labels = renderer_context.get('labels', self.labels)
-
         if not isinstance(data, list):
             data = [data]
 
-        table = self.tablize(data)
+        header = renderer_context.get('header', self.header)
+        labels = renderer_context.get('labels', self.labels)
+
+        table = self.tablize(data, header=header, labels=labels)
         csv_buffer = Echo()
         csv_writer = csv.writer(csv_buffer)
         for row in table:

--- a/rest_framework_csv/tests.py
+++ b/rest_framework_csv/tests.py
@@ -75,6 +75,7 @@ class TestCSVRenderer (TestCase):
                                  {'b': 3, 'c': [4, 5]},
                                  6],
                                 labels={'a':'A', 'c.0': '0c'})
+
         self.assertEqual(flat, [[''  , 'A' , 'b' , '0c' , 'c.1'],
                                 [None, 1   , 2   , None  , None ],
                                 [None, None, 3   , 4     , 5    ],
@@ -171,7 +172,8 @@ class TestCSVStreamingRenderer(TestCase):
 
     def setUp(self):
         self.header = ['a', 'b']
-        self.data = [{'a': 1, 'b': 2}]
+        self.data = [{'a': 1, 'b': 2, 'c': 3}]
+        self.labels = {'a': 'Aa'}
 
     def test_renderer_return_type(self):
         renderer = CSVStreamingRenderer()
@@ -182,9 +184,11 @@ class TestCSVStreamingRenderer(TestCase):
     def test_renderer_value(self):
         renderer = CSVRenderer()
         renderer.header = self.header
+        renderer.labels = self.labels
 
         streaming_renderer = CSVStreamingRenderer()
         streaming_renderer.header = self.header
+        streaming_renderer.labels = self.labels
 
         renderer_data = renderer.render(self.data)
         streaming_renderer_data = ''.join(streaming_renderer.render(self.data))


### PR DESCRIPTION
Hey @mjumbewu - thanks again for this repo.

I may be missing something here, but it seems to me that explicitly setting headers <a href="https://github.com/mjumbewu/django-rest-framework-csv/blob/26d7e66169480e0cf0dc373c1f0f9e4ca43bde82/rest_framework_csv/renderers.py#L192">like in the example</a> for <code> CSVStreamingRenderer </code>does not have an impact on the resulting CSV. I think this commit fixes that issue (and I believe the same issue exists for labels). I updated the unit tests accordingly. Let me know what you think, and thanks again. 