### PR TITLE
Added django.contrib.contenttypes to testsettings.INSTALLED_APPS

### DIFF
--- a/testsettings.py
+++ b/testsettings.py
@@ -6,6 +6,7 @@ DATABASES = {
 }
 
 INSTALLED_APPS = (
+    'django.contrib.contenttypes',
     'rest_framework_csv',
 )
 


### PR DESCRIPTION
Tests were failing for more recent Django versions. Adding `django.contrib.contenttypes` fixes the error.

```
======================================================================
ERROR: rest_framework_csv.tests (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: rest_framework_csv.tests
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/home/andrew/Development/repos/django-rest-framework-csv/rest_framework_csv/tests.py", line 10, in <module>
    from .renderers import CSVRenderer, CSVStreamingRenderer
  File "/home/andrew/Development/repos/django-rest-framework-csv/rest_framework_csv/renderers.py", line 4, in <module>
    from rest_framework.renderers import *
  File "/home/andrew/Development/repos/django-rest-framework-csv/.tox/py36-django19-drf2/lib/python3.6/site-packages/rest_framework/renderers.py", line 20, in <module>
    from rest_framework.compat import StringIO, smart_text, yaml
  File "/home/andrew/Development/repos/django-rest-framework-csv/.tox/py36-django19-drf2/lib/python3.6/site-packages/rest_framework/compat.py", line 284, in <module>
    from django.contrib.contenttypes.fields import GenericForeignKey
  File "/home/andrew/Development/repos/django-rest-framework-csv/.tox/py36-django19-drf2/lib/python3.6/site-packages/django/contrib/contenttypes/fields.py", line 5, in <module>
    from django.contrib.contenttypes.models import ContentType
  File "/home/andrew/Development/repos/django-rest-framework-csv/.tox/py36-django19-drf2/lib/python3.6/site-packages/django/contrib/contenttypes/models.py", line 161, in <module>
    class ContentType(models.Model):
  File "/home/andrew/Development/repos/django-rest-framework-csv/.tox/py36-django19-drf2/lib/python3.6/site-packages/django/db/models/base.py", line 102, in __new__
    "INSTALLED_APPS." % (module, name)
RuntimeError: Model class django.contrib.contenttypes.models.ContentType doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)

```