### PR TITLE
Support Non UTF-8 Encoding Parsing

### DIFF
--- a/rest_framework_csv/parsers.py
+++ b/rest_framework_csv/parsers.py
@@ -11,7 +11,7 @@ from rest_framework_csv.orderedrows import OrderedRows
 
 
 def unicode_csv_reader(csv_data, dialect=csv.excel, charset='utf-8', **kwargs):
-    csv_reader = csv.reader(csv_data, dialect=dialect, **kwargs)
+    csv_reader = csv.reader(csv_data, dialect=dialect, encoding=charset, **kwargs)
     for row in csv_reader:
         yield row
 

--- a/rest_framework_csv/tests.py
+++ b/rest_framework_csv/tests.py
@@ -257,3 +257,10 @@ class TestCSVParser(TestCase):
 
         data = parser.parse(BytesIO(csv_file))
         self.assertEqual(data, [{'col1': 'hello—goodbye', 'col2': 'here—there'}])
+
+    def test_shift_jis_parsing(self):
+        parser = CSVParser()
+        csv_file = 'col1,col2\r\nシフトジス,シフトジス2'.encode('shift-jis')
+
+        data = parser.parse(BytesIO(csv_file), parser_context={'encoding': 'SHIFT_JIS'})
+        self.assertEqual(data, [{'col1': 'シフトジス', 'col2': 'シフトジス2'}])


### PR DESCRIPTION
Without passing the `encoding`/`charset` parameter to `csv.reader`,
the following exception will be raised when trying to parse non utf-8 encoded csv.
```
rest_framework.exceptions.ParseError: CSV parse error - 'utf-8' codec can't decode byte 0x83 in position 0: invalid start byte
```