### PR TITLE
Reference the internal PaginatedCSVRenderer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,21 +106,10 @@ attribute directly:
 Pagination
 ----------
 
-Using the renderer with paginated data is also possible, with a little extension.
-A paginated CSV renderer is constructed like below, and should be used with views
-that paginate data
+Using the renderer with paginated data is also possible with the
+new `PaginatedCSVRenderer` class and should be used with views that
+paginate data
 
-.. code-block:: python
-
-    from rest_framework_csv.renderers import CSVRenderer
-
-    class PaginatedCSVRenderer (CSVRenderer):
-        results_field = 'results'
-
-        def render(self, data, *args, **kwargs):
-            if not isinstance(data, list):
-                data = data.get(self.results_field, [])
-            return super(PaginatedCSVRenderer, self).render(data, *args, **kwargs)
 
 For more information about using renderers with Django REST Framework, see the
 `API Guide <http://django-rest-framework.org/api-guide/renderers/>`_ or the


### PR DESCRIPTION
Reference the internal PaginatedCSVRenderer instead of instructing users to write their own.

This is included here: https://github.com/mjumbewu/django-rest-framework-csv/blob/master/rest_framework_csv/renderers.py#L234
