### PR TITLE
added labels to parser for changing column names

### DIFF
--- a/rest_framework_csv/tests.py
+++ b/rest_framework_csv/tests.py
@@ -264,3 +264,16 @@ class TestCSVParser(TestCase):
 
         data = parser.parse(BytesIO(csv_file), parser_context={'encoding': 'SHIFT_JIS'})
         self.assertEqual(data, [{'col1': 'シフトジス', 'col2': 'シフトジス2'}])
+
+    def test_labels(self):
+        parser = CSVParser()
+        labels = {
+            'Name': 'name',
+            'Surname': 'surname',
+        }
+        setattr(parser, 'labels', labels)
+        csv_file = 'Name,Surname\r\nvasya,pupkin'.encode('utf-8')
+        data = parser.parse(BytesIO(csv_file), parser_context={'encoding': 'utf-8'})
+        self.assertEqual(data, [{'name': 'vasya', 'surname': 'pupkin'}])
+
+


### PR DESCRIPTION
Hi, 
I've met the same issue as [Issue#74](https://github.com/mjumbewu/django-rest-framework-csv/issues/74) and decided to share my solution.

The problem:
I wanted to serialize data coming from csv file. But the problem with column names, so solved it like in renderer class. just added **labels** attribute which changes column names (coming from csv) with field names.

just visa versa to renderer. 

Hope that it's fine
Thanks.

