### PR TITLE
Add column header setting

### DIFF
--- a/rest_framework_csv/parsers.py
+++ b/rest_framework_csv/parsers.py
@@ -43,16 +43,13 @@ class CSVParser(BaseParser):
         if 'view' in parser_context:
             if hasattr(parser_context['view'], 'csv_header'):
                 header = parser_context['view'].csv_header
-                print("using header")
 
         try:
             strdata = stream.read()
             binary = universal_newlines(strdata)
             rows = unicode_csv_reader(binary, delimiter=delimiter, charset=encoding)
             data = OrderedRows(header or next(rows))
-            print(f"data header: {data.header}")
             for row in rows:
-                print(f"Adding csv row: {row}")
                 row_data = dict(zip(data.header, row))
                 data.append(row_data)
             return data

--- a/rest_framework_csv/parsers.py
+++ b/rest_framework_csv/parsers.py
@@ -39,15 +39,19 @@ class CSVParser(BaseParser):
         delimiter = parser_context.get('delimiter', ',')
         encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
 
+        header = None
+        if 'view' in parser_context:
+            if hasattr(parser_context['view'].__class__, 'csv_header'):
+                header = parser_context['view'].__class__.csv_header
+
         try:
             strdata = stream.read()
             binary = universal_newlines(strdata)
             rows = unicode_csv_reader(binary, delimiter=delimiter, charset=encoding)
-            data = OrderedRows(next(rows))
+            data = OrderedRows(header or next(rows))
             for row in rows:
                 row_data = dict(zip(data.header, row))
                 data.append(row_data)
             return data
         except Exception as exc:
             raise ParseError('CSV parse error - %s' % str(exc))
-

--- a/rest_framework_csv/parsers.py
+++ b/rest_framework_csv/parsers.py
@@ -29,7 +29,9 @@ class CSVParser(BaseParser):
     """
     Parses CSV serialized data.
 
-    The parser assumes the first line contains the column names.
+    The parser uses the column names defined in the csv_header 
+    viewset class property if defined. Otherwise, the parser uses 
+    the first row of the CSV data.
     """
 
     media_type = 'text/csv'

--- a/rest_framework_csv/parsers.py
+++ b/rest_framework_csv/parsers.py
@@ -42,14 +42,17 @@ class CSVParser(BaseParser):
         header = None
         if 'view' in parser_context:
             if hasattr(parser_context['view'], 'csv_header'):
-                header = parser_context['view'].__class__.csv_header
+                header = parser_context['view'].csv_header
+                print("using header")
 
         try:
             strdata = stream.read()
             binary = universal_newlines(strdata)
             rows = unicode_csv_reader(binary, delimiter=delimiter, charset=encoding)
             data = OrderedRows(header or next(rows))
+            print(f"data header: {data.header}")
             for row in rows:
+                print(f"Adding csv row: {row}")
                 row_data = dict(zip(data.header, row))
                 data.append(row_data)
             return data

--- a/rest_framework_csv/parsers.py
+++ b/rest_framework_csv/parsers.py
@@ -41,7 +41,7 @@ class CSVParser(BaseParser):
 
         header = None
         if 'view' in parser_context:
-            if hasattr(parser_context['view'].__class__, 'csv_header'):
+            if hasattr(parser_context['view'], 'csv_header'):
                 header = parser_context['view'].__class__.csv_header
 
         try:


### PR DESCRIPTION
This PR adds the ability to define the CSV column order from within the code
Currently, the CSV Parser assumes the first row of CSV data contains the column names.

This PR adds the ability to define the column names from the ViewSet class:
```python
class CSVEndpoint(viewsets.ModelViewSet):
    serializer_class = CSVSerializer
    parser_classes = (CSVParser,)

    csv_header = ("time", "temperature")
```
There are still a few small things I would like to address before this is merged. Namely

- [ ] Is the viewset class the appropriate place to define the `csv_header` variable?
- [ ] Testing? I've only manually-tested this with my own project so far.
- [ ] Code style, this is quick and dirty; is there more django-y way of doing this?

Thanks