### PR TITLE
Returning empty csv file when there is no data

### DIFF
--- a/rest_framework_csv/renderers.py
+++ b/rest_framework_csv/renderers.py
@@ -58,7 +58,7 @@ class CSVRenderer(BaseRenderer):
 
         return csv_buffer.getvalue()
 
-    def tablize(self, data, header=None, labels=None):
+    def tablize(self, data=[], header=None, labels=None):
         """
         Convert a list of data into a table.
 


### PR DESCRIPTION
When queryset returns zero items `django-rest-framework-csv` returns just empty response, we need to return an empty CSV file instead