### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/rest_framework_csv/tests.py
+++ b/rest_framework_csv/tests.py
@@ -139,7 +139,7 @@ class TestCSVRenderer (TestCase):
         }
         renderer.writer_opts = writer_opts
         dump = renderer.render(data)
-        self.assertEquals(dump.count(b';'), 3)
+        self.assertEqual(dump.count(b';'), 3)
         self.assertIn(b"|test|", dump)
         self.assertIn(b"|hello|", dump)
 
@@ -153,7 +153,7 @@ class TestCSVRenderer (TestCase):
             'delimiter': ';' if PY3 else b';',
         }
         dump = renderer.render(data, renderer_context={'writer_opts': writer_opts})
-        self.assertEquals(dump.count(b';'), 3)
+        self.assertEqual(dump.count(b';'), 3)
         self.assertIn(b"|test|", dump)
         self.assertIn(b"|hello|", dump)
 
@@ -191,7 +191,7 @@ class TestCSVStreamingRenderer(TestCase):
         renderer_list_dump = renderer.render(self.data)
         self.assertIsInstance(renderer_generator_dump, GeneratorType)
         self.assertIsInstance(renderer_list_dump, GeneratorType)
-        self.assertEquals(list(renderer_generator_dump), list(renderer_list_dump))
+        self.assertEqual(list(renderer_generator_dump), list(renderer_list_dump))
 
 
 class TestPaginatedCSVRenderer(TestCase):


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268