### PR TITLE
Testing newer Python and Django versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+on:
+  workflow_dispatch:
+  #push:
+  #  branches: [master]
+  #pull_request:
+  #  branches: [master]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-and-quality
+    
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,13 +72,13 @@ jobs:
           - python: 3.9
             TOXENV: py39-django42-drf3
 
-          - python: 3.10
+          - python: '3.10'
             TOXENV: py310-django32-drf3
-          - python: 3.10
+          - python: '3.10'
             TOXENV: py310-django40-drf3
-          - python: 3.10
+          - python: '3.10'
             TOXENV: py310-django41-drf3
-          - python: 3.10
+          - python: '3.10'
             TOXENV: py310-django42-drf3
 
           - python: 3.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,80 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Python ${{ matrix.env.python }} | ${{ matrix.env.TOXENV }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - python: 2.7
+            TOXENV: py27-django18-drf2
+          - python: 2.7
+            TOXENV: py36-django18-drf36
+          - python: 2.7
+            TOXENV: py36-django111-drf2
+          - python: 2.7
+            TOXENV: py36-django111-drf36
+
+          - python: 3.5
+            TOXENV: py35-django18-drf2
+          - python: 3.5
+            TOXENV: py35-django18-drf36
+          - python: 3.5
+            TOXENV: py35-django111-drf2
+          - python: 3.5
+            TOXENV: py35-django111-drf36
+
+          - python: 3.6
+            TOXENV: py36-django111-drf3
+          - python: 3.6
+            TOXENV: py36-django21-drf3
+          - python: 3.6
+            TOXENV: py36-django22-drf3
+
+          - python: 3.7
+            TOXENV: py37-django21-drf3
+          - python: 3.7
+            TOXENV: py37-django22-drf3
+          - python: 3.7
+            TOXENV: py37-django30-drf3
+
+          - python: 3.8
+            TOXENV: py38-django21-drf3
+          - python: 3.8
+            TOXENV: py38-django22-drf3
+          - python: 3.8
+            TOXENV: py38-django30-drf3
+          - python: 3.8
+            TOXENV: py38-django31-drf3
+          - python: 3.8
+            TOXENV: py38-django32-drf3
+
+          - python: 3.9
+            TOXENV: py39-django22-drf3
+          - python: 3.9
+            TOXENV: py39-django30-drf3
+          - python: 3.9
+            TOXENV: py39-django31-drf3
+          - python: 3.9
+            TOXENV: py39-django32-drf3
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.env.python }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run Tests
+        env:
+          TOXENV: django${{ matrix.env.TOXENV }}
+        run: tox -e ${{ matrix.env.TOXENV }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,22 +23,6 @@ jobs:
           - python: 2.7
             TOXENV: py27-django111-drf36
 
-          - python: 3.5
-            TOXENV: py35-django18-drf2
-          - python: 3.5
-            TOXENV: py35-django18-drf36
-          - python: 3.5
-            TOXENV: py35-django111-drf2
-          - python: 3.5
-            TOXENV: py35-django111-drf36
-
-          - python: 3.6
-            TOXENV: py36-django111-drf3
-          - python: 3.6
-            TOXENV: py36-django21-drf3
-          - python: 3.6
-            TOXENV: py36-django22-drf3
-
           - python: 3.7
             TOXENV: py37-django21-drf3
           - python: 3.7
@@ -81,12 +65,6 @@ jobs:
           - python: '3.10'
             TOXENV: py310-django42-drf3
 
-          - python: 3.11
-            TOXENV: py311-django40-drf3
-          - python: 3.11
-            TOXENV: py311-django41-drf3
-          - python: 3.11
-            TOXENV: py311-django42-drf3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Python ${{ matrix.env.python }} | ${{ matrix.env.TOXENV }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +80,13 @@ jobs:
             TOXENV: py310-django41-drf3
           - python: 3.10
             TOXENV: py310-django42-drf3
+
+          - python: 3.11
+            TOXENV: py311-django40-drf3
+          - python: 3.11
+            TOXENV: py311-django41-drf3
+          - python: 3.11
+            TOXENV: py311-django42-drf3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,21 @@ jobs:
             TOXENV: py39-django31-drf3
           - python: 3.9
             TOXENV: py39-django32-drf3
+          - python: 3.9
+            TOXENV: py39-django40-drf3
+          - python: 3.9
+            TOXENV: py39-django41-drf3
+          - python: 3.9
+            TOXENV: py39-django42-drf3
+
+          - python: 3.10
+            TOXENV: py310-django32-drf3
+          - python: 3.10
+            TOXENV: py310-django40-drf3
+          - python: 3.10
+            TOXENV: py310-django41-drf3
+          - python: 3.10
+            TOXENV: py310-django42-drf3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - python: 2.7
             TOXENV: py27-django111-drf2
           - python: 2.7
-            TOXENV: py36-django111-drf36
+            TOXENV: py27-django111-drf36
 
           - python: 3.5
             TOXENV: py35-django18-drf2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
           - python: 2.7
             TOXENV: py27-django18-drf2
           - python: 2.7
-            TOXENV: py36-django18-drf36
+            TOXENV: py27-django18-drf36
           - python: 2.7
-            TOXENV: py36-django111-drf2
+            TOXENV: py27-django111-drf2
           - python: 2.7
             TOXENV: py36-django111-drf36
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,10 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Framework :: Django",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py27-django{18,111}-drf{2,36},
     py35-django{18,111}-drf{2,36},
     py36-django{111,21,22}-drf3
+    py37-django{21,22,30}-drf3
+    py38-django{21,22,30,31,32}-drf3
+    py39-django{22,30,31,32}-drf3
 
 [testenv]
 commands = python manage.py test
@@ -11,6 +14,9 @@ deps =
     django111: Django>=1.11,<2.0
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     drf2: djangorestframework>=2,<3
     drf36: djangorestframework>=3,<3.7
     drf3: djangorestframework>=3,<4

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = py27-django{18,111}-drf{2,36},
     py36-django{111,21,22}-drf3
     py37-django{21,22,30}-drf3
     py38-django{21,22,30,31,32}-drf3
-    py39-django{22,30,31,32}-drf3
+    py39-django{22,30,31,32,41,42}-drf3
+    py310-django{32,40,41,42}-drf3
 
 [testenv]
 commands = python manage.py test
@@ -17,6 +18,8 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     drf2: djangorestframework>=2,<3
     drf36: djangorestframework>=3,<3.7
     drf3: djangorestframework>=3,<4


### PR DESCRIPTION
Build on top of pull request of [awais786](https://github.com/awais786) and the CodeQL from [arpitjain799](https://github.com/arpitjain799), adding python version 3.10 and Django 4.

Python 3.11 is not included as this starts to need some code refactoring.