### PR TITLE
Update tested versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   build:
-    name: Python ${{ matrix.env.python }} | ${{ matrix.env.TOXENV }}
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
         - 3.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,52 +11,24 @@ jobs:
     name: Python ${{ matrix.env.python }} | ${{ matrix.env.TOXENV }}
     runs-on: ubuntu-22.04
     strategy:
-      fail-fast: false
       matrix:
-        env:
-          - python: 3.8
-            TOXENV: py38-django32
-
-          - python: 3.9
-            TOXENV: py39-django32
-          - python: 3.9
-            TOXENV: py39-django42
-
-          - python: '3.10'
-            TOXENV: py310-django32
-          - python: '3.10'
-            TOXENV: py310-django42
-          - python: '3.10'
-            TOXENV: py310-django50
-          - python: '3.10'
-            TOXENV: py310-django51
-
-          - python: '3.11'
-            TOXENV: py311-django42
-          - python: '3.11'
-            TOXENV: py311-django50
-          - python: '3.11'
-            TOXENV: py311-django51
-
-          - python: '3.12'
-            TOXENV: py312-django42
-          - python: '3.12'
-            TOXENV: py312-django50
-          - python: '3.12'
-            TOXENV: py312-django51
-
-          - python: '3.13'
-            TOXENV: py313-django51
+        python-version:
+        - 3.9
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - '3.13'
 
     steps:
       - uses: actions/checkout@v4
+
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.env.python }}
+          python-version: ${{ matrix.python-version }}
+
       - name: Install tox
         run: pip install tox
-      - name: Run Tests
-        env:
-          TOXENV: django${{ matrix.env.TOXENV }}
-        run: tox -e ${{ matrix.env.TOXENV }}
+
+      - name: Run tox targets for ${{ matrix.python-version }}
+        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,14 @@ To run the tests against the current environment:
 Changelog
 =========
 
+Pending
+-------
+
+- Add compatibility with Python 3.12 and 3.13.
+- Remove compatibility with Python 3.8.
+- Add compatibility with Django 5.1 and 5.2.
+- Remove compatibility with Django 3.2, 4.0, and 4.1.
+
 3.0.2
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Django",
     ],
 )

--- a/testsettings.py
+++ b/testsettings.py
@@ -13,8 +13,3 @@ INSTALLED_APPS = (
 )
 
 SECRET_KEY = 'testsecretkey'
-
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware'
-)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    py38-django{32}
-    py39-django{32,42}
-    py310-django{32,42,50,51}
-    py311-django{42,50,51}
-    py312-django{42,50,51}
-    py313-django{51}
+    py39-django{42}
+    py310-django{42,50,51,52}
+    py311-django{42,50,51,52}
+    py312-django{42,50,51,52}
+    py313-django{51,52}
 
 [testenv]
 set_env =
@@ -17,7 +16,7 @@ commands =
       -m django test
 deps =
     djangorestframework<4
-    django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2a1,<6.0


### PR DESCRIPTION
1. Drop Python 3.8 which is EOL.
2. Drop Django 3.2, 4.0, and 4.1, which are EOL.
3. Add Python 3.13.
4. Add Django 5.2.
5. Refactor CI to run one job per Python version. This is what I do on my projects ([example](https://github.com/adamchainz/django-htmx/blob/main/.github/workflows/main.yml)) and it saves a lot of CI time, as the repeat runs within the same version can reuse cached packages. It’s also way simpler to maintain as it doesn’t repeat so much of the grid in `tox.ini`.